### PR TITLE
Fix Makefile build targets

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -21,7 +21,6 @@ MIPS_TARGETS := mips-unknown-linux-gnu \
 	mips64el-unknown-linux-gnuabi64
 
 $(TARGETS):
-$(MIPS_TARGETS):
 	cross build --target $@ --release
 
 par: $(TARGETS)
@@ -48,6 +47,9 @@ par: $(TARGETS)
 		--arch x86_64-linux \
 		--binary target/x86_64-unknown-linux-gnu/release/lib$(LIBNAME).so \
 		lib$(LIBNAME).par.gz
+
+$(MIPS_TARGETS):
+	cross build --target $@ --release
 
 par-mips: $(MIPS_TARGETS) par 
 	wash par insert \

--- a/fs/Makefile
+++ b/fs/Makefile
@@ -21,7 +21,6 @@ MIPS_TARGETS := mips-unknown-linux-gnu \
 	mips64el-unknown-linux-gnuabi64
 
 $(TARGETS):
-$(MIPS_TARGETS):
 	cross build --target $@ --release
 
 par: $(TARGETS)
@@ -48,6 +47,9 @@ par: $(TARGETS)
 		--arch x86_64-linux \
 		--binary target/x86_64-unknown-linux-gnu/release/lib$(LIBNAME).so \
 		lib$(LIBNAME).par.gz
+
+$(MIPS_TARGETS):
+	cross build --target $@ --release
 
 par-mips: $(MIPS_TARGETS) par 
 	wash par insert \

--- a/http-client/Makefile
+++ b/http-client/Makefile
@@ -21,7 +21,6 @@ MIPS_TARGETS := mips-unknown-linux-gnu \
 	mips64el-unknown-linux-gnuabi64
 
 $(TARGETS):
-$(MIPS_TARGETS):
 	cross build --target $@ --release
 
 par: $(TARGETS)
@@ -48,6 +47,9 @@ par: $(TARGETS)
 		--arch x86_64-linux \
 		--binary target/x86_64-unknown-linux-gnu/release/lib$(LIBNAME).so \
 		lib$(LIBNAME).par.gz
+
+$(MIPS_TARGETS):
+	cross build --target $@ --release
 
 par-mips: $(MIPS_TARGETS) par 
 	wash par insert \

--- a/http-server/Makefile
+++ b/http-server/Makefile
@@ -21,7 +21,6 @@ MIPS_TARGETS := mips-unknown-linux-gnu \
 	mips64el-unknown-linux-gnuabi64
 
 $(TARGETS):
-$(MIPS_TARGETS):
 	cross build --target $@ --release
 
 par: $(TARGETS)
@@ -48,6 +47,9 @@ par: $(TARGETS)
 		--arch x86_64-linux \
 		--binary target/x86_64-unknown-linux-gnu/release/lib$(LIBNAME).so \
 		lib$(LIBNAME).par.gz
+
+$(MIPS_TARGETS):
+	cross build --target $@ --release
 
 par-mips: $(MIPS_TARGETS) par 
 	wash par insert \

--- a/logging/Makefile
+++ b/logging/Makefile
@@ -21,7 +21,6 @@ MIPS_TARGETS := mips-unknown-linux-gnu \
 	mips64el-unknown-linux-gnuabi64
 
 $(TARGETS):
-$(MIPS_TARGETS):
 	cross build --target $@ --release
 
 par: $(TARGETS)
@@ -48,6 +47,9 @@ par: $(TARGETS)
 		--arch x86_64-linux \
 		--binary target/x86_64-unknown-linux-gnu/release/lib$(LIBNAME).so \
 		lib$(LIBNAME).par.gz
+
+$(MIPS_TARGETS):
+	cross build --target $@ --release
 
 par-mips: $(MIPS_TARGETS) par 
 	wash par insert \

--- a/nats/Makefile
+++ b/nats/Makefile
@@ -21,7 +21,6 @@ MIPS_TARGETS := mips-unknown-linux-gnu \
 	mips64el-unknown-linux-gnuabi64
 
 $(TARGETS):
-$(MIPS_TARGETS):
 	cross build --target $@ --release
 
 par: $(TARGETS)
@@ -48,6 +47,9 @@ par: $(TARGETS)
 		--arch x86_64-linux \
 		--binary target/x86_64-unknown-linux-gnu/release/lib$(LIBNAME).so \
 		lib$(LIBNAME).par.gz
+
+$(MIPS_TARGETS):
+	cross build --target $@ --release
 
 par-mips: $(MIPS_TARGETS) par 
 	wash par insert \

--- a/redis-streams/Makefile
+++ b/redis-streams/Makefile
@@ -21,7 +21,6 @@ MIPS_TARGETS := mips-unknown-linux-gnu \
 	mips64el-unknown-linux-gnuabi64
 
 $(TARGETS):
-$(MIPS_TARGETS):
 	cross build --target $@ --release
 
 par: $(TARGETS)
@@ -48,6 +47,9 @@ par: $(TARGETS)
 		--arch x86_64-linux \
 		--binary target/x86_64-unknown-linux-gnu/release/lib$(LIBNAME).so \
 		lib$(LIBNAME).par.gz
+
+$(MIPS_TARGETS):
+	cross build --target $@ --release
 
 par-mips: $(MIPS_TARGETS) par 
 	wash par insert \

--- a/redis/Makefile
+++ b/redis/Makefile
@@ -21,7 +21,6 @@ MIPS_TARGETS := mips-unknown-linux-gnu \
 	mips64el-unknown-linux-gnuabi64
 
 $(TARGETS):
-$(MIPS_TARGETS):
 	cross build --target $@ --release
 
 par: $(TARGETS)
@@ -48,6 +47,9 @@ par: $(TARGETS)
 		--arch x86_64-linux \
 		--binary target/x86_64-unknown-linux-gnu/release/lib$(LIBNAME).so \
 		lib$(LIBNAME).par.gz
+
+$(MIPS_TARGETS):
+	cross build --target $@ --release
 
 par-mips: $(MIPS_TARGETS) par 
 	wash par insert \

--- a/redisgraph/Makefile
+++ b/redisgraph/Makefile
@@ -21,7 +21,6 @@ MIPS_TARGETS := mips-unknown-linux-gnu \
 	mips64el-unknown-linux-gnuabi64
 
 $(TARGETS):
-$(MIPS_TARGETS):
 	cross build --target $@ --release
 
 par: $(TARGETS)
@@ -48,6 +47,9 @@ par: $(TARGETS)
 		--arch x86_64-linux \
 		--binary target/x86_64-unknown-linux-gnu/release/lib$(LIBNAME).so \
 		lib$(LIBNAME).par.gz
+
+$(MIPS_TARGETS):
+	cross build --target $@ --release
 
 par-mips: $(MIPS_TARGETS) par 
 	wash par insert \

--- a/s3/Makefile
+++ b/s3/Makefile
@@ -21,7 +21,6 @@ MIPS_TARGETS := mips-unknown-linux-gnu \
 	mips64el-unknown-linux-gnuabi64
 
 $(TARGETS):
-$(MIPS_TARGETS):
 	cross build --target $@ --release
 
 par: $(TARGETS)
@@ -48,6 +47,9 @@ par: $(TARGETS)
 		--arch x86_64-linux \
 		--binary target/x86_64-unknown-linux-gnu/release/lib$(LIBNAME).so \
 		lib$(LIBNAME).par.gz
+
+$(MIPS_TARGETS):
+	cross build --target $@ --release
 
 par-mips: $(MIPS_TARGETS) par 
 	wash par insert \

--- a/telnet/Makefile
+++ b/telnet/Makefile
@@ -21,7 +21,6 @@ MIPS_TARGETS := mips-unknown-linux-gnu \
 	mips64el-unknown-linux-gnuabi64
 
 $(TARGETS):
-$(MIPS_TARGETS):
 	cross build --target $@ --release
 
 par: $(TARGETS)
@@ -48,6 +47,9 @@ par: $(TARGETS)
 		--arch x86_64-linux \
 		--binary target/x86_64-unknown-linux-gnu/release/lib$(LIBNAME).so \
 		lib$(LIBNAME).par.gz
+
+$(MIPS_TARGETS):
+	cross build --target $@ --release
 
 par-mips: $(MIPS_TARGETS) par 
 	wash par insert \


### PR DESCRIPTION
The common Makefile had an error that resulted in `cross build ...` not getting called.