### PR TITLE
Idempotent configuration binding and support for health checks

### DIFF
--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wascc-httpsrv"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 homepage = "https://wascc.dev"

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wascc-nats"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 homepage = "https://wascc.dev"
@@ -29,7 +29,7 @@ env_logger = "0.7.1"
 crossbeam-channel = "0.4.2"
 crossbeam = "0.7.3"
 crossbeam-utils = "^0.7.0"
-nats = "0.8.1"
+nats = "0.8.6"
 serde_bytes = "0.11.5"
 rmp-serde = "0.14.4"
 serde = {version = "1.0.117", features = ["derive"]}

--- a/nats/src/generated/core.rs
+++ b/nats/src/generated/core.rs
@@ -12,13 +12,13 @@ pub struct CapabilityConfiguration {
 }
 
 #[derive(Debug, PartialEq, Deserialize, Serialize, Default, Clone)]
-pub struct HealthCheckRequest {
+pub struct HealthRequest {
     #[serde(rename = "placeholder")]
     pub placeholder: bool,
 }
 
 #[derive(Debug, PartialEq, Deserialize, Serialize, Default, Clone)]
-pub struct HealthCheckResponse {
+pub struct HealthResponse {
     #[serde(rename = "healthy")]
     pub healthy: bool,
     #[serde(rename = "message")]

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wascc-redis"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 homepage = "https://wascc.dev"


### PR DESCRIPTION
0.15.x requires that all capability providers:
* Gracefully ignore attempts at binding actors that are already bound
* Support returning a health status in response to a health check